### PR TITLE
986064: Resolve Failures in GitHub Repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # React-Scheduler-CRUD-using-axios
 
-We have prepared a sample using Axios library method for performing CRUD actions in scheduler. 
+This repository demonstrates how to implement CRUD operations in a React Scheduler component using the Axios library for API communication. It is designed as a practical example for developers who want to integrate scheduling functionality with backend services in a React application.
 
-Please find the service project from below link.
-  
-Service: https://www.syncfusion.com/downloads/support/forum/172013/ze/Service90807893310072088141574866169
+We have prepared a sample using Axios library method for performing CRUD actions in the scheduler. This example shows how to create, read, update, and delete events efficiently while maintaining a responsive user interface.
 
-Note: Run service project first to perform CRUD action.
+Please find the service project from the link below:
+
+Service:
+https://www.syncfusion.com/downloads/support/forum/172013/ze/Service90807893310072088141574866169
+
+Note: Run the service project first to perform CRUD actions successfully. The service acts as the backend API that handles data persistence for the scheduler component.
+
+This sample is useful for understanding how to configure Axios requests, handle responses, and manage state updates in React.


### PR DESCRIPTION
### Bug description
[986064](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/986064/): Resolve Failures in GitHub Repositories

### Root cause,
The repository readme must have a minimum length of 1000 characters, whereas the current readme length is less than 1000 characters

### Reason for not identifying earlier
Find how it was missed in our earlier testing and development by analysing the below checklist. This will help prevent similar mistakes in the future. 

 - [x] Guidelines/documents are not followed

    - Specification document

 - [ ] Guidelines/documents are not given

    - Common guidelines / Core team guideline
    - Specification document
    - Requirement document


### Reason:

I have resolved by add the content in Readme description.

### Output screenshots:

NA

### Action taken:

I have resolved by add the content in Readme description.

### Related areas:

NA

### Is it a breaking issue?

No

### Solution description

I have resolved by add the content in Readme description.

### Areas affected and ensured

NA

### Additional checklist
This may vary for different teams or products. Check with your scrum masters.

  - Did you run the automation against your fix? Yes
  - Is there any API name change? No
  - Is there any existing behavior change of other features due to this code change? No
  - Does your new code introduce new warnings or binding errors? No
  - Does your code pass all FxCop and StyleCop rules? NA
  - Did you record this case in the unit test or UI test? NA
  - 